### PR TITLE
Support for adwords dynamic remarketing.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ AdWords.prototype.loaded = function() {
 AdWords.prototype.page = function() {
   var remarketing = !!this.options.remarketing;
   var id = this.options.conversionId;
-  var props = {};
+  var props = window.google_tag_params || {};
   window.google_trackConversion({
     google_conversion_id: id,
     google_custom_params: props,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,6 +76,21 @@ describe('AdWords', function() {
           google_remarketing_only: true
         });
       });
+
+      it('should send the optional params if present in the window object', function(){
+        window.google_tag_params = {
+          dynx_itemid: ['1'],
+          dynx_pagetype: 'offerdetail',
+          dynx_totalvalue: '42'
+        };
+        adwords.options.remarketing = true;
+        analytics.page();
+        analytics.called(window.google_trackConversion, {
+          google_conversion_id: options.conversionId,
+          google_custom_params: window.google_tag_params,
+          google_remarketing_only: true
+        });
+      });
     });
 
     describe('#track', function() {


### PR DESCRIPTION
Pass the window.google_tag_params as google_custom_params in the remarketing call.
Fixes #2 
