### PR TITLE
Dynamic remarketing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,11 @@ AdWords.prototype.track = function(track) {
   var events = this.events(track.event());
   var revenue = track.revenue() || 0;
   each(function(label) {
-    var props = remarketing ? extend(track.properties(), window.google_custom_params) : {};
+    // We technically don't need to send the props as far as GA docs 
+    // are concerned but to be safe in regards to backward compat (since
+    // we always used to send props regardless of `remarketing` flag)
+    // we'll keep sending the props
+    var props = extend(track.properties(), remarketing ? window.google_custom_params : {});
     delete props.revenue;
     window.google_trackConversion({
       google_conversion_id: id,

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ AdWords.prototype.loaded = function() {
 
 AdWords.prototype.page = function(page) {
   // https://developers.google.com/adwords-remarketing-tag/asynchronous/
-  var remarketing = !!this.options.remarketing;
+  var remarketing = this.options.remarketing;
   var id = this.options.conversionId;
   // it's okay to send custom props even if customers dont use dynamic remarketing
   // "if this variable is not provided, static remarketing rules can still be generated in AdWords by using URL-based rules."
@@ -74,7 +74,7 @@ AdWords.prototype.page = function(page) {
  */
 
 AdWords.prototype.track = function(track) {
-  var remarketing = !!this.options.remarketing;
+  var remarketing = this.options.remarketing;
   var id = this.options.conversionId;
   var events = this.events(track.event());
   var revenue = track.revenue() || 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@
 
 var each = require('@ndhoule/each');
 var integration = require('@segment/analytics.js-integration');
+var extend = require('@ndhoule/extend');
 
 /**
  * Expose `AdWords`.
@@ -54,7 +55,8 @@ AdWords.prototype.page = function(page) {
   // https://developers.google.com/adwords-remarketing-tag/asynchronous/
   var remarketing = !!this.options.remarketing;
   var id = this.options.conversionId;
-  var props = remarketing ? page.properties() : {};
+  // customers may have custom instance of google params on the window
+  var props = remarketing ? extend(page.properties(), window.google_custom_params) : {};
   window.google_trackConversion({
     google_conversion_id: id,
     google_custom_params: props,
@@ -75,7 +77,7 @@ AdWords.prototype.track = function(track) {
   var events = this.events(track.event());
   var revenue = track.revenue() || 0;
   each(function(label) {
-    var props = track.properties();
+    var props = remarketing ? extend(track.properties(), window.google_custom_params) : {};
     delete props.revenue;
     window.google_trackConversion({
       google_conversion_id: id,

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,8 @@ AdWords.prototype.page = function(page) {
   // https://developers.google.com/adwords-remarketing-tag/asynchronous/
   var remarketing = !!this.options.remarketing;
   var id = this.options.conversionId;
+  // it's okay to send custom props even if customers dont use dynamic remarketing
+  // "if this variable is not provided, static remarketing rules can still be generated in AdWords by using URL-based rules."
   // customers may have custom instance of google params on the window
   var props = remarketing ? extend(page.properties(), window.google_custom_params) : {};
   window.google_trackConversion({

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,10 +50,11 @@ AdWords.prototype.loaded = function() {
  * @param {Page} page
  */
 
-AdWords.prototype.page = function() {
+AdWords.prototype.page = function(page) {
+  // https://developers.google.com/adwords-remarketing-tag/asynchronous/
   var remarketing = !!this.options.remarketing;
   var id = this.options.conversionId;
-  var props = {};
+  var props = remarketing ? page.properties() : {};
   window.google_trackConversion({
     google_conversion_id: id,
     google_custom_params: props,
@@ -69,6 +70,7 @@ AdWords.prototype.page = function() {
  */
 
 AdWords.prototype.track = function(track) {
+  var remarketing = !!this.options.remarketing;
   var id = this.options.conversionId;
   var events = this.events(track.event());
   var revenue = track.revenue() || 0;
@@ -83,7 +85,7 @@ AdWords.prototype.track = function(track) {
       google_conversion_color: 'ffffff',
       google_conversion_label: label,
       google_conversion_value: revenue,
-      google_remarketing_only: false
+      google_remarketing_only: remarketing
     });
   }, events);
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-adwords#readme",
   "dependencies": {
     "@ndhoule/each": "^2.0.1",
+    "@ndhoule/extend": "^2.0.0",
     "@segment/analytics.js-integration": "^2.1.0"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,13 @@ describe('AdWords', function() {
         analytics.page();
         analytics.called(window.google_trackConversion, {
           google_conversion_id: options.conversionId,
-          google_custom_params: {},
+          google_custom_params: {
+            path: window.location.pathname,
+            referrer: document.referrer,
+            search: '',
+            title: '',
+            url: window.location.href
+          },
           google_remarketing_only: true
         });
       });
@@ -132,18 +138,18 @@ describe('AdWords', function() {
         });
       });
 
-      it('should always send remarketing_only false', function() {
+      it('should support remarketing if enabled', function() {
         adwords.options.remarketing = true;
-        analytics.track('login', { revenue: 90 });
+        analytics.track('login', { revenue: 90, custom: 'summer sixteen' });
         analytics.called(window.google_trackConversion, {
           google_conversion_id: options.conversionId,
-          google_custom_params: {},
+          google_custom_params: { custom: 'summer sixteen' },
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
           google_conversion_label: options.events.login,
           google_conversion_value: 90,
-          google_remarketing_only: false
+          google_remarketing_only: true
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,11 +83,36 @@ describe('AdWords', function() {
           google_remarketing_only: true
         });
       });
+
+      it('should load remarketing with page props and window.google_custom_params', function() {
+        adwords.options.remarketing = true;
+        window.google_custom_params = {
+          dynx_itemid: ['1'],
+          dynx_pagetype: 'offerdetail',
+          dynx_totalvalue: '42'
+        };
+        analytics.page();
+        analytics.called(window.google_trackConversion, {
+          google_conversion_id: options.conversionId,
+          google_custom_params: {
+            path: window.location.pathname,
+            referrer: document.referrer,
+            search: '',
+            title: '',
+            url: window.location.href,
+            dynx_itemid: ['1'],
+            dynx_pagetype: 'offerdetail',
+            dynx_totalvalue: '42'
+          },
+          google_remarketing_only: true
+        });
+      });
     });
 
     describe('#track', function() {
       beforeEach(function() {
         analytics.stub(window, 'google_trackConversion');
+        delete window.google_custom_params;
       });
 
       it('should not send if event is not defined', function() {
@@ -144,6 +169,31 @@ describe('AdWords', function() {
         analytics.called(window.google_trackConversion, {
           google_conversion_id: options.conversionId,
           google_custom_params: { custom: 'summer sixteen' },
+          google_conversion_language: 'en',
+          google_conversion_format: '3',
+          google_conversion_color: 'ffffff',
+          google_conversion_label: options.events.login,
+          google_conversion_value: 90,
+          google_remarketing_only: true
+        });
+      });
+
+      it('should send custom params from window with properties for remarketing', function() {
+        window.google_custom_params = {
+          dynx_itemid: ['1'],
+          dynx_pagetype: 'offerdetail',
+          dynx_totalvalue: '42'
+        };
+        adwords.options.remarketing = true;
+        analytics.track('login', { revenue: 90, custom: 'summer sixteen' });
+        analytics.called(window.google_trackConversion, {
+          google_conversion_id: options.conversionId,
+          google_custom_params: { 
+            custom: 'summer sixteen',
+            dynx_itemid: ['1'],
+            dynx_pagetype: 'offerdetail',
+            dynx_totalvalue: '42'
+          },
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',


### PR DESCRIPTION
This resolves: https://segment.atlassian.net/browse/INT-647

Also took some ideas from existing [PR](https://github.com/segment-integrations/analytics.js-integration-adwords/pull/4)!

I want to merge `window.google_custom_params` because google's documentation around this feature all suggest to set the custom params there so I think it'd be harmless to just join it if it exists with the `.page()` or `.track()` properties.

@myclamm @f2prateek @sperand-io 
