### PR TITLE
PLATFORM-1559: Supporting multiple AdWords conversion_IDs for one source

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ AdWords.prototype.track = function(track) {
 
   eventMappings.forEach(function(mapping) {
     if (mapping.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
-    var id = mapping.value.conversionId ||  self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
+    var id = mapping.value.conversionId ||  self.options.conversionId;  // customer can either specify one global conversion id or one per  mapping
 
     // Fire conversion tag
     if (mapping.value.label !== '') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,9 +14,8 @@ var when = require('do-when');
 
 var AdWords = module.exports = integration('AdWords')
   .option('conversionId', '')
-  .option('remarketing', false)
-  .option('whitelist', {})
-  .option('labelMap', [])
+  .option('pageRemarketing', false)
+  .option('eventMappings', [])
   .tag('<script src="//www.googleadservices.com/pagead/conversion_async.js">');
 
 /**
@@ -59,7 +58,7 @@ AdWords.prototype.loaded = function() {
 AdWords.prototype.page = function(page) {
   // Remarketing option can support both Adwords' "static" or "dynamic" remarketing tags
   // Difference is static you don't need to send props under `google_custom_params`
-  var remarketing = this.options.remarketing;
+  var remarketing = this.options.pageRemarketing;
   var id = this.options.conversionId;
   var props = page.properties();
 
@@ -91,60 +90,38 @@ AdWords.prototype.page = function(page) {
 AdWords.prototype.track = function(track) {
   var self = this;
   var props = track.properties();
-  var remarketing = this.options.remarketing;
-  var labelMap = this.options.labelMap;
+  var eventMappings = this.options.eventMappings;
   var revenue = track.revenue() || 0;
-  var remarketingSent = {}; // for each conversion id tracks whether a remarketing tag has been sent yet
 
-  if (labelMap) { // if labelmap exists then the new metadata schema is being used
-    labelMap.forEach(function(mapping) {
-      if (typeof mapping.value.eventName !== 'string' || typeof track.event() !== 'string') return;
-      
+  if (eventMappings) { // if eventMappings exists then the new metadata schema is being used
+    eventMappings.forEach(function(mapping) {
       if (mapping.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
-      var id = mapping.value.conversionId || self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
-      delete props.revenue;
+      var id = mapping.value.conversionId === '' ?  self.options.conversionId : mapping.value.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
 
       // Fire conversion tag
-      window.google_trackConversion({
-        google_conversion_id: id,
-        google_custom_params: props,
-        google_conversion_language: 'en',
-        google_conversion_format: '3',
-        google_conversion_color: 'ffffff',
-        google_conversion_label: mapping.value.label,
-        google_conversion_value: revenue,
-        google_remarketing_only: false // ensure this is a conversion tag
-      });
+      if (mapping.value.label !== '') {
+      delete props.revenue;
+      
+        window.google_trackConversion({
+          google_conversion_id: id,
+          google_custom_params: props,
+          google_conversion_language: 'en',
+          google_conversion_format: '3',
+          google_conversion_color: 'ffffff',
+          google_conversion_label: mapping.value.label,
+          google_conversion_value: revenue,
+          google_remarketing_only: false // ensure this is a conversion tag
+        });
+      }
 
       // Fire remarketing tag
-      if (!(id in remarketingSent) && remarketing) {
+      if (mapping.value.remarketing) {
         window.google_trackConversion({
           google_conversion_id: id,
           google_custom_params: props, // do not send PII here!
           google_remarketing_only: true // ensure this is a remarketing tag
         });
-        remarketingSent[id] = true;
       }
-    });
-
-    var whitelist = this.options.whitelist;
-
-    whitelist.forEach(function(listing) {
-      if (typeof listing.value.eventName !== 'string' || typeof track.event() !== 'string') return;
-      if (listing.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
-
-      var conversionIds = listing.value.conversionIds;
-      if (conversionIds.length < 1) conversionIds.push(self.options.conversionId);
-
-      conversionIds.forEach(function(conversionId) {
-        if (conversionId in remarketingSent) return;
-
-        window.google_trackConversion({
-          google_conversion_id: conversionId,
-          google_custom_params: props, // do not send PII here!
-          google_remarketing_only: true // ensure this is a remarketing tag
-        });
-      });
     });
   } 
   // DELETE BELOW AND TAKE ABOVE OUT OF IF CLAUSE, only exists for metadata cutover
@@ -154,6 +131,7 @@ AdWords.prototype.track = function(track) {
     // Check if this is a whitelisted event for standalone remarketing tag
     var whitelisted = this.options.whitelist.indexOf(track.event()) > -1;
     var sentAlready = false;
+    var remarketing = this.options.remarketing;
   
     each(function(label) {
       delete props.revenue;

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ AdWords.prototype.track = function(track) {
 
       // Fire conversion tag
       if (mapping.value.label !== '') {
-      delete props.revenue;
+        delete props.revenue;
       
         window.google_trackConversion({
           google_conversion_id: id,

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
  */
 
 var integration = require('@segment/analytics.js-integration');
+var each = require('@ndhoule/each');
 var when = require('do-when');
 
 /**
@@ -93,38 +94,92 @@ AdWords.prototype.track = function(track) {
   var remarketing = this.options.remarketing;
   var labelMap = this.options.labelMap;
   var revenue = track.revenue() || 0;
-  var remarketingSent = false;
+  var remarketingSent = {}; // for each conversion id tracks whether a remarketing tag has been sent yet
 
-  labelMap.forEach(function(mapping) {
-    if (mapping.event !== track.event()) return;
-    var id = mapping.conversionId || self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
-    delete props.revenue;
-    // Fire conversion tag
-    window.google_trackConversion({
-      google_conversion_id: id,
-      google_custom_params: props,
-      google_conversion_language: 'en',
-      google_conversion_format: '3',
-      google_conversion_color: 'ffffff',
-      google_conversion_label: mapping.label,
-      google_conversion_value: revenue,
-      google_remarketing_only: false // ensure this is a conversion tag
-    });
-    // Fire remarketing tag
-    if (!remarketingSent && remarketing) {
+  if (labelMap) { // if labelmap exists then the new metadata schema is being used
+    labelMap.forEach(function(mapping) {
+      if (typeof mapping.value.eventName !== 'string' || typeof track.event() !== 'string') return;
+      
+      if (mapping.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
+      var id = mapping.value.conversionId || self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
+      delete props.revenue;
+
+      // Fire conversion tag
       window.google_trackConversion({
         google_conversion_id: id,
-        google_custom_params: props, // do not send PII here!
-        google_remarketing_only: true // ensure this is a remarketing tag
+        google_custom_params: props,
+        google_conversion_language: 'en',
+        google_conversion_format: '3',
+        google_conversion_color: 'ffffff',
+        google_conversion_label: mapping.value.label,
+        google_conversion_value: revenue,
+        google_remarketing_only: false // ensure this is a conversion tag
       });
-      remarketingSent = true;
-    }
-  });
 
-  var whitelist = this.options.whitelist;
-  if (whitelist.hasOwnProperty(track.event())) {
-    var id = whitelist[track.event()] || this.options.conversionId;
-    if (!remarketingSent) {
+      // Fire remarketing tag
+      if (!(id in remarketingSent) && remarketing) {
+        window.google_trackConversion({
+          google_conversion_id: id,
+          google_custom_params: props, // do not send PII here!
+          google_remarketing_only: true // ensure this is a remarketing tag
+        });
+        remarketingSent[id] = true;
+      }
+    });
+
+    var whitelist = this.options.whitelist;
+
+    whitelist.forEach(function(listing) {
+      if (typeof listing.value.eventName !== 'string' || typeof track.event() !== 'string') return;
+      if (listing.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
+
+      var conversionIds = listing.value.conversionIds;
+      if (conversionIds.length < 1) conversionIds.push(self.options.conversionId);
+
+      conversionIds.forEach(function(conversionId) {
+        if (conversionId in remarketingSent) return;
+
+        window.google_trackConversion({
+          google_conversion_id: conversionId,
+          google_custom_params: props, // do not send PII here!
+          google_remarketing_only: true // ensure this is a remarketing tag
+        });
+      });
+    });
+  } 
+  // DELETE BELOW AND TAKE ABOVE OUT OF IF CLAUSE, only exists for metadata cutover
+  else {  // eslint-disable-line
+    var id = this.options.conversionId;
+    var events = this.events(track.event());
+    // Check if this is a whitelisted event for standalone remarketing tag
+    var whitelisted = this.options.whitelist.indexOf(track.event()) > -1;
+    var sentAlready = false;
+  
+    each(function(label) {
+      delete props.revenue;
+      // Fire conversion tag
+      window.google_trackConversion({
+        google_conversion_id: id,
+        google_custom_params: props,
+        google_conversion_language: 'en',
+        google_conversion_format: '3',
+        google_conversion_color: 'ffffff',
+        google_conversion_label: label,
+        google_conversion_value: revenue,
+        google_remarketing_only: false // ensure this is a conversion tag
+      });
+      // Fire remarketing tag
+      if (!sentAlready && remarketing) {
+        window.google_trackConversion({
+          google_conversion_id: id,
+          google_custom_params: props, // do not send PII here!
+          google_remarketing_only: true // ensure this is a remarketing tag
+        });
+        sentAlready = true;
+      }
+    }, events);
+  
+    if (!sentAlready && whitelisted) {
       window.google_trackConversion({
         google_conversion_id: id,
         google_custom_params: props, // do not send PII here!

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,76 +93,33 @@ AdWords.prototype.track = function(track) {
   var eventMappings = this.options.eventMappings;
   var revenue = track.revenue() || 0;
 
-  if (eventMappings) { // if eventMappings exists then the new metadata schema is being used
-    eventMappings.forEach(function(mapping) {
-      if (mapping.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
-      var id = mapping.value.conversionId ||  self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
+  eventMappings.forEach(function(mapping) {
+    if (mapping.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
+    var id = mapping.value.conversionId ||  self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
 
-      // Fire conversion tag
-      if (mapping.value.label !== '') {
-        delete props.revenue;
-      
-        window.google_trackConversion({
-          google_conversion_id: id,
-          google_custom_params: props,
-          google_conversion_language: 'en',
-          google_conversion_format: '3',
-          google_conversion_color: 'ffffff',
-          google_conversion_label: mapping.value.label,
-          google_conversion_value: revenue,
-          google_remarketing_only: false // ensure this is a conversion tag
-        });
-      }
-
-      // Fire remarketing tag
-      if (mapping.value.remarketing) {
-        window.google_trackConversion({
-          google_conversion_id: id,
-          google_custom_params: props, // do not send PII here!
-          google_remarketing_only: true // ensure this is a remarketing tag
-        });
-      }
-    });
-  } 
-  // TODO: DELETE BELOW AND TAKE ABOVE OUT OF IF CLAUSE, only exists for metadata cutover so if you're seeing this you can delete this block!
-  else {  // eslint-disable-line
-    var id = this.options.conversionId;
-    var events = this.events(track.event());
-    // Check if this is a whitelisted event for standalone remarketing tag
-    var whitelisted = this.options.whitelist.indexOf(track.event()) > -1;
-    var sentAlready = false;
-    var remarketing = this.options.remarketing;
-  
-    each(function(label) {
+    // Fire conversion tag
+    if (mapping.value.label !== '') {
       delete props.revenue;
-      // Fire conversion tag
+    
       window.google_trackConversion({
         google_conversion_id: id,
         google_custom_params: props,
         google_conversion_language: 'en',
         google_conversion_format: '3',
         google_conversion_color: 'ffffff',
-        google_conversion_label: label,
+        google_conversion_label: mapping.value.label,
         google_conversion_value: revenue,
         google_remarketing_only: false // ensure this is a conversion tag
       });
-      // Fire remarketing tag
-      if (!sentAlready && remarketing) {
-        window.google_trackConversion({
-          google_conversion_id: id,
-          google_custom_params: props, // do not send PII here!
-          google_remarketing_only: true // ensure this is a remarketing tag
-        });
-        sentAlready = true;
-      }
-    }, events);
-  
-    if (!sentAlready && whitelisted) {
+    }
+
+    // Fire remarketing tag
+    if (mapping.value.remarketing) {
       window.google_trackConversion({
         google_conversion_id: id,
         google_custom_params: props, // do not send PII here!
         google_remarketing_only: true // ensure this is a remarketing tag
       });
     }
-  }
+  });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
  * Module dependencies.
  */
 
-var each = require('@ndhoule/each');
 var integration = require('@segment/analytics.js-integration');
 var when = require('do-when');
 
@@ -16,8 +15,7 @@ var AdWords = module.exports = integration('AdWords')
   .option('conversionId', '')
   .option('remarketing', false)
   .option('whitelist', [])
-  .tag('<script src="//www.googleadservices.com/pagead/conversion_async.js">')
-  .mapping('events');
+  .tag('<script src="//www.googleadservices.com/pagead/conversion_async.js">');
 
 /**
  * Initialize.
@@ -89,16 +87,16 @@ AdWords.prototype.page = function(page) {
  */
 
 AdWords.prototype.track = function(track) {
-  var id = this.options.conversionId;
+  var self = this;
   var props = track.properties();
   var remarketing = this.options.remarketing;
-  var events = this.events(track.event());
+  var labelMap = this.options.labelMap;
   var revenue = track.revenue() || 0;
-  // Check if this is a whitelisted event for standalone remarketing tag
-  var whitelisted = this.options.whitelist.indexOf(track.event()) > -1;
-  var sentAlready = false;
+  var remarketingSent = false;
 
-  each(function(label) {
+  labelMap.forEach(function(mapping) {
+    if (mapping.event !== track.event()) return;
+    var id = mapping.conversionId || self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
     delete props.revenue;
     // Fire conversion tag
     window.google_trackConversion({
@@ -107,26 +105,30 @@ AdWords.prototype.track = function(track) {
       google_conversion_language: 'en',
       google_conversion_format: '3',
       google_conversion_color: 'ffffff',
-      google_conversion_label: label,
+      google_conversion_label: mapping.label,
       google_conversion_value: revenue,
       google_remarketing_only: false // ensure this is a conversion tag
     });
     // Fire remarketing tag
-    if (!sentAlready && remarketing) {
+    if (!remarketingSent && remarketing) {
       window.google_trackConversion({
         google_conversion_id: id,
         google_custom_params: props, // do not send PII here!
         google_remarketing_only: true // ensure this is a remarketing tag
       });
-      sentAlready = true;
+      remarketingSent = true;
     }
-  }, events);
+  });
 
-  if (!sentAlready && whitelisted) {
-    window.google_trackConversion({
-      google_conversion_id: id,
-      google_custom_params: props, // do not send PII here!
-      google_remarketing_only: true // ensure this is a remarketing tag
-    });
+  var whitelist = this.options.whitelist;
+  if (whitelist.hasOwnProperty(track.event())) {
+    var id = whitelist[track.event()] || this.options.conversionId;
+    if (!remarketingSent) {
+      window.google_trackConversion({
+        google_conversion_id: id,
+        google_custom_params: props, // do not send PII here!
+        google_remarketing_only: true // ensure this is a remarketing tag
+      });
+    }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@
  */
 
 var integration = require('@segment/analytics.js-integration');
-var each = require('@ndhoule/each');
 var when = require('do-when');
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ var when = require('do-when');
 var AdWords = module.exports = integration('AdWords')
   .option('conversionId', '')
   .option('remarketing', false)
-  .option('whitelist', [])
+  .option('whitelist', {})
+  .option('labelMap', [])
   .tag('<script src="//www.googleadservices.com/pagead/conversion_async.js">');
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ AdWords.prototype.track = function(track) {
   if (eventMappings) { // if eventMappings exists then the new metadata schema is being used
     eventMappings.forEach(function(mapping) {
       if (mapping.value.eventName.toLowerCase() !== track.event().toLowerCase()) return;
-      var id = mapping.value.conversionId === '' ?  self.options.conversionId : mapping.value.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
+      var id = mapping.value.conversionId ||  self.options.conversionId;  // customer can either specify one global conversion id or one per event<->label mapping
 
       // Fire conversion tag
       if (mapping.value.label !== '') {
@@ -124,7 +124,7 @@ AdWords.prototype.track = function(track) {
       }
     });
   } 
-  // DELETE BELOW AND TAKE ABOVE OUT OF IF CLAUSE, only exists for metadata cutover
+  // TODO: DELETE BELOW AND TAKE ABOVE OUT OF IF CLAUSE, only exists for metadata cutover so if you're seeing this you can delete this block!
   else {  // eslint-disable-line
     var id = this.options.conversionId;
     var events = this.events(track.event());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,16 +13,25 @@ describe('AdWords', function() {
     conversionId: 978352801,
     labelMap: [
       {
-        event: 'signup',
-        label: '-kGkCJ_TsgcQofXB0gM'
+        key: 'signup',
+        value: {
+          eventName: 'signup',
+          label: '-kGkCJ_TsgcQofXB0gM'
+        }
       },
       {
-        event: 'login',
-        label: 'QbThCM_zogcQofXB0gM'
+        key: 'login',
+        value: {
+          eventName: 'login',
+          label: 'QbThCM_zogcQofXB0gM'
+        }
       },
       {
-        event: 'play',
-        label: 'b91fc77f'
+        key: 'play',
+        value: {
+          eventName: 'play',
+          label: 'b91fc77f'
+        }
       }
     ]
   };
@@ -45,7 +54,9 @@ describe('AdWords', function() {
   it('should have the correct settings', function() {
     analytics.compare(AdWords, integration('AdWords')
       .option('conversionId', '')
-      .option('remarketing', false));
+      .option('remarketing', false)
+      .option('whitelist', [])
+      .option('labelMap', []));
   });
 
   describe('loading', function() {
@@ -120,7 +131,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[0].label,
+          google_conversion_label: options.labelMap[0].value.label,
           google_conversion_value: 0,
           google_remarketing_only: false
         });
@@ -129,20 +140,30 @@ describe('AdWords', function() {
       it('should use mapping specific IDs if provided', function() {
         adwords.options.labelMap = [
           {
-            event: 'signup',
-            label: '-kGkCJ_TsgcQofXB0gM',
-            conversionId: 431
+            key: 'signup',
+            value: {
+              eventName: 'signup',
+              label: '-kGkCJ_TsgcQofXB0gM',
+              conversionId: 431
+            }
           },
           {
-            event: 'login',
-            label: 'QbThCM_zogcQofXB0gM',
-            conversionId: 367
+            key: 'login',
+            value: {
+              eventName: 'login',
+              label: 'QbThCM_zogcQofXB0gM',
+              conversionId: 23
+            }
           },
           {
-            event: 'play',
-            label: 'b91fc77f',
-            conversionId: 109
-          }];
+            key: 'play',
+            value: {
+              eventName: 'play',
+              label: 'b91fc77f',
+              conversionId: 4512
+            }
+          }
+        ];
         analytics.track('signup', {});
         analytics.called(window.google_trackConversion, {
           google_conversion_id: 431,
@@ -150,14 +171,14 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[0].label,
+          google_conversion_label: options.labelMap[0].value.label,
           google_conversion_value: 0,
           google_remarketing_only: false
         });
       });
 
       it('should use whitelisted event-specific ID when provided', function() {
-        adwords.options.whitelist = { 'danny mcbride is funny': 4879235 };
+        adwords.options.whitelist = [{ value: { eventName: 'danny mcbride is funny', conversionIds: [4879235] } }];
         analytics.track('danny mcbride is funny', { revenue: 90 });
         analytics.calledOnce(window.google_trackConversion);
         analytics.deepEqual(window.google_trackConversion.args[0], [{
@@ -165,7 +186,7 @@ describe('AdWords', function() {
           google_custom_params: { revenue: 90 },
           google_remarketing_only: true
         }]);
-      })
+      });
 
       it('should send revenue', function() {
         analytics.track('login', { revenue: 90 });
@@ -175,7 +196,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].label,
+          google_conversion_label: options.labelMap[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         });
@@ -190,7 +211,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].label,
+          google_conversion_label: options.labelMap[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         });
@@ -206,14 +227,14 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].label,
+          google_conversion_label: options.labelMap[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         }]);
       });
 
       it('should send only the remarketing tag if no conversions are mapped but is whitelisted', function() {
-        adwords.options.whitelist = { 'danny mcbride is funny': null };
+        adwords.options.whitelist = [{ value: { eventName: 'danny mcbride is funny', conversionIds: [] } }];
         analytics.track('danny mcbride is funny', { revenue: 90 });
         analytics.calledOnce(window.google_trackConversion);
         analytics.deepEqual(window.google_trackConversion.args[0], [{
@@ -233,7 +254,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].label,
+          google_conversion_label: options.labelMap[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         }]);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,29 +11,36 @@ describe('AdWords', function() {
   var analytics;
   var options = {
     conversionId: 978352801,
-    labelMap: [
+    eventMappings: [
       {
         key: 'signup',
         value: {
           eventName: 'signup',
-          label: '-kGkCJ_TsgcQofXB0gM'
+          label: '-kGkCJ_TsgcQofXB0gM',
+          conversionId: '',
+          remarketing: false
         }
       },
       {
         key: 'login',
         value: {
           eventName: 'login',
-          label: 'QbThCM_zogcQofXB0gM'
+          label: 'QbThCM_zogcQofXB0gM',
+          conversionId: '',
+          remarketing: false
         }
       },
       {
         key: 'play',
         value: {
           eventName: 'play',
-          label: 'b91fc77f'
+          label: 'b91fc77f',
+          conversionId: '',
+          remarketing: false
         }
       }
-    ]
+    ],
+    pageRemarketing: false
   };
 
   beforeEach(function() {
@@ -54,9 +61,8 @@ describe('AdWords', function() {
   it('should have the correct settings', function() {
     analytics.compare(AdWords, integration('AdWords')
       .option('conversionId', '')
-      .option('remarketing', false)
-      .option('whitelist', [])
-      .option('labelMap', []));
+      .option('pageRemarketing', false)
+      .option('eventMappings', []));
   });
 
   describe('loading', function() {
@@ -78,7 +84,7 @@ describe('AdWords', function() {
       });
 
       it('should not load remarketing if option is not on', function() {
-        adwords.options.remarketing = false;
+        adwords.options.pageRemarketing = false;
         analytics.page();
         analytics.calledOnce(window.google_trackConversion);
         analytics.deepEqual(window.google_trackConversion.args[0], [{
@@ -89,7 +95,7 @@ describe('AdWords', function() {
       });
 
       it('should fire additional remarketing tag if option is on', function() {
-        adwords.options.remarketing = true;
+        adwords.options.pageRemarketing = true;
         analytics.page();
         analytics.calledTwice(window.google_trackConversion);
         // fire conversion tag first
@@ -131,14 +137,14 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[0].value.label,
+          google_conversion_label: options.eventMappings[0].value.label,
           google_conversion_value: 0,
           google_remarketing_only: false
         });
       });
 
       it('should use mapping specific IDs if provided', function() {
-        adwords.options.labelMap = [
+        adwords.options.eventMappings = [
           {
             key: 'signup',
             value: {
@@ -148,19 +154,11 @@ describe('AdWords', function() {
             }
           },
           {
-            key: 'login',
+            key: 'signup',
             value: {
-              eventName: 'login',
+              eventName: 'signup',
               label: 'QbThCM_zogcQofXB0gM',
               conversionId: 23
-            }
-          },
-          {
-            key: 'play',
-            value: {
-              eventName: 'play',
-              label: 'b91fc77f',
-              conversionId: 4512
             }
           }
         ];
@@ -171,14 +169,24 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[0].value.label,
+          google_conversion_label: options.eventMappings[0].value.label,
+          google_conversion_value: 0,
+          google_remarketing_only: false
+        });
+        analytics.called(window.google_trackConversion, {
+          google_conversion_id: 23,
+          google_custom_params: {},
+          google_conversion_language: 'en',
+          google_conversion_format: '3',
+          google_conversion_color: 'ffffff',
+          google_conversion_label: options.eventMappings[1].value.label,
           google_conversion_value: 0,
           google_remarketing_only: false
         });
       });
 
-      it('should use whitelisted event-specific ID when provided', function() {
-        adwords.options.whitelist = [{ value: { eventName: 'danny mcbride is funny', conversionIds: [4879235] } }];
+      it('should send remarketing along with conversion if both are enabled', function() {
+        adwords.options.eventMappings = [{ value: { eventName: 'danny mcbride is funny', conversionId: 4879235, remarketing: true, label: '' } }];
         analytics.track('danny mcbride is funny', { revenue: 90 });
         analytics.calledOnce(window.google_trackConversion);
         analytics.deepEqual(window.google_trackConversion.args[0], [{
@@ -196,7 +204,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].value.label,
+          google_conversion_label: options.eventMappings[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         });
@@ -211,7 +219,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].value.label,
+          google_conversion_label: options.eventMappings[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         });
@@ -227,14 +235,14 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].value.label,
+          google_conversion_label: options.eventMappings[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         }]);
       });
 
       it('should send only the remarketing tag if no conversions are mapped but is whitelisted', function() {
-        adwords.options.whitelist = [{ value: { eventName: 'danny mcbride is funny', conversionIds: [] } }];
+        adwords.options.eventMappings = [{ value: { eventName: 'danny mcbride is funny', conversionId: '', remarketing: true, label: '' } }];
         analytics.track('danny mcbride is funny', { revenue: 90 });
         analytics.calledOnce(window.google_trackConversion);
         analytics.deepEqual(window.google_trackConversion.args[0], [{
@@ -245,7 +253,7 @@ describe('AdWords', function() {
       });
 
       it('should send both conversion and remarketing tag if remarketing is true', function() {
-        adwords.options.remarketing = true;
+        adwords.options.eventMappings[1].value.remarketing = true;
         analytics.track('login', { revenue: 90, hello: 'foo' });
         analytics.calledTwice(window.google_trackConversion);
         analytics.deepEqual(window.google_trackConversion.args[0], [{
@@ -254,7 +262,7 @@ describe('AdWords', function() {
           google_conversion_language: 'en',
           google_conversion_format: '3',
           google_conversion_color: 'ffffff',
-          google_conversion_label: options.labelMap[1].value.label,
+          google_conversion_label: options.eventMappings[1].value.label,
           google_conversion_value: 90,
           google_remarketing_only: false
         }]);
@@ -263,13 +271,6 @@ describe('AdWords', function() {
           google_custom_params: { hello: 'foo' },
           google_remarketing_only: true
         }]);
-      });
-
-      it('should not double send remarketing tag as a standalone if it was already sent with conversion tag', function() {
-        adwords.options.remarketing = true;
-        analytics.track('login', { revenue: 90, hello: 'foo' });
-        // It would be called three times if it sent duplicate
-        analytics.calledTwice(window.google_trackConversion);
       });
     });
   });


### PR DESCRIPTION
Transformed the event<->label mapping from a key-value store (in the form of an object) to a list of mappings that each hold an event name, label name, conversion id, and a 'remarketing' flag that indicates whether or not an additional remarketing call should be sent.

Removed the whitelist setting since its functionality is now included in the event map's 'remarketing' setting

https://segment.atlassian.net/browse/PLATFORM-1559